### PR TITLE
FEAT: /timer Command

### DIFF
--- a/src/main/kotlin/noammaddons/commands/CommandManager.kt
+++ b/src/main/kotlin/noammaddons/commands/CommandManager.kt
@@ -11,7 +11,8 @@ object CommandManager {
         DungeonHub,
         End,
         Skyblock,
-        hub
+        hub,
+        TimerCommand
     )
 
     fun registerCommands() {

--- a/src/main/kotlin/noammaddons/commands/commands/TimerCommand.kt
+++ b/src/main/kotlin/noammaddons/commands/commands/TimerCommand.kt
@@ -41,10 +41,10 @@ object TimerCommand: Command("timer") {
      */
     private fun logoutFromServer() {
         Minecraft.getMinecraft().addScheduledTask {
-            Minecraft.getMinecraft().theWorld = null;
-            Minecraft.getMinecraft().thePlayer = null;
-            Minecraft.getMinecraft().displayGuiScreen(GuiMainMenu());
-        };
+            Minecraft.getMinecraft().theWorld = null
+            Minecraft.getMinecraft().thePlayer = null
+            Minecraft.getMinecraft().displayGuiScreen(GuiMainMenu())
+        }
     }
 
     /**
@@ -107,7 +107,6 @@ object TimerCommand: Command("timer") {
         timerThread = thread(start = true, isDaemon = true, name = "TimerCommandThread") {
             try {
                 Thread.sleep(seconds * 1000L)
-                val modes = arrayOf("logout", "quit game", "run command")
                 val actions = arrayOf(
                     { logoutFromServer() },
                     { quitGame() },
@@ -119,6 +118,7 @@ object TimerCommand: Command("timer") {
                 actions.getOrNull(clientTimerMode)?.invoke()
             } catch(e: InterruptedException) {
                 modMessage("&cTimer interrupted due to an error or user action.")
+                println(e)
             }
         }
     }

--- a/src/main/kotlin/noammaddons/commands/commands/TimerCommand.kt
+++ b/src/main/kotlin/noammaddons/commands/commands/TimerCommand.kt
@@ -1,0 +1,125 @@
+/**
+ * Noamm Addons - Timer Command
+ * This file has been automagically been JSdoc'ed by https://axle.coffee using OpenAI's GPT-4.1
+ * This file is part of the Noamm Addons project, which is licensed under the undefined license.
+ * This code may be subject to personal license(s) used by axle.coffee or other third parties, please contact a Contributor for more information.
+ *
+ */
+package noammaddons.commands.commands
+
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiMainMenu
+import net.minecraft.command.ICommandSender
+import noammaddons.commands.Command
+import noammaddons.features.impl.misc.ClientTimer.clientTimerCommand
+import noammaddons.features.impl.misc.ClientTimer.clientTimerCommandOnAllModes
+import noammaddons.features.impl.misc.ClientTimer.clientTimerMode
+import noammaddons.utils.ChatUtils.modMessage
+import noammaddons.utils.ChatUtils.sendChatMessage
+import kotlin.concurrent.thread
+
+/**
+ * Handles the /timer command for scheduling actions after a delay.
+ *
+ * Usage:
+ * /timer <time><unit>
+ * Examples: /timer 1d, /timer 2h, /timer 30m, /timer 45s, /timer 1hour
+ *
+ * Modes:
+ * - logout: Disconnects from the server and returns to the main menu.
+ * - quit game: Shuts down the Minecraft client.
+ * - run command: Executes a custom command after the timer.
+ *
+ * If called with no arguments and a timer is running, cancels the timer.
+ */
+object TimerCommand: Command("timer") {
+    private var timerThread: Thread? = null
+
+    /**
+     * Disconnects the player from the current server and returns to the main menu.
+     * We shedule this task to ensure it runs on the main thread which owns openGL or smth (idk ask google)
+     */
+    private fun logoutFromServer() {
+        Minecraft.getMinecraft().addScheduledTask {
+            Minecraft.getMinecraft().theWorld = null;
+            Minecraft.getMinecraft().thePlayer = null;
+            Minecraft.getMinecraft().displayGuiScreen(GuiMainMenu());
+        };
+    }
+
+    /**
+     * Shuts down the Minecraft client.
+     */
+    private fun quitGame() {
+        Minecraft.getMinecraft().shutdown()
+    }
+
+    /**
+     * Parses a time argument string into seconds.
+     * Supports days, hours, minutes, seconds, and their full-word variants.
+     *
+     * @param input The time argument string.
+     * @return The total time in seconds.
+     */
+    private fun parseTimeArg(input: String): Int {
+        val units = arrayOf(
+            Pair(Regex("""(\d+)\s*d(ays?)?""", RegexOption.IGNORE_CASE), 86400),
+            Pair(Regex("""(\d+)\s*h(ours?)?""", RegexOption.IGNORE_CASE), 3600),
+            Pair(Regex("""(\d+)\s*m(in(utes?)?)?""", RegexOption.IGNORE_CASE), 60),
+            Pair(Regex("""(\d+)\s*s(ec(onds?)?)?""", RegexOption.IGNORE_CASE), 1),
+        )
+        for((regex, multiplier) in units) {
+            val match = regex.find(input)
+            if(match != null) {
+                val value = match.groupValues[1].toIntOrNull() ?: 0
+                return value * multiplier
+            }
+        }
+        return input.filter { it.isDigit() }.toIntOrNull() ?: 0
+    }
+
+    /**
+     * Processes the /timer command.
+     * Cancels any running timer if called with no arguments.
+     * Otherwise, starts a new timer for the specified duration and executes the selected action.
+     *
+     * @param sender The command sender.
+     * @param args The command arguments.
+     */
+    override fun processCommand(sender: ICommandSender, args: Array<out String>) {
+        if(args.isEmpty()) {
+            if(timerThread?.isAlive == true) {
+                timerThread?.interrupt()
+                timerThread = null
+                modMessage("&aTimer cancelled.")
+            } else {
+                modMessage("&cInvalid Usage. &bUsage: /timer <time><unit>")
+            }
+            return
+        }
+        val seconds = parseTimeArg(args.joinToString(" "))
+        if(seconds <= 0) {
+            modMessage("&cInvalid time. Please provide a positive duration.")
+            return
+        }
+        modMessage("&aTimer set for $seconds seconds.")
+        timerThread?.interrupt()
+        timerThread = thread(start = true, isDaemon = true, name = "TimerCommandThread") {
+            try {
+                Thread.sleep(seconds * 1000L)
+                val modes = arrayOf("logout", "quit game", "run command")
+                val actions = arrayOf(
+                    { logoutFromServer() },
+                    { quitGame() },
+                    { if(clientTimerCommand.isNotEmpty()) sendChatMessage(clientTimerCommand) },
+                )
+                if(clientTimerCommandOnAllModes && clientTimerCommand.isNotEmpty()) {
+                    sendChatMessage(clientTimerCommand)
+                }
+                actions.getOrNull(clientTimerMode)?.invoke()
+            } catch(e: InterruptedException) {
+                modMessage("&cTimer interrupted due to an error or user action.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/noammaddons/features/FeatureManager.kt
+++ b/src/main/kotlin/noammaddons/features/FeatureManager.kt
@@ -45,7 +45,7 @@ object FeatureManager {
         TeleportOverlay, CustomScoreboard, BlockOverlay, CustomWardrobeMenu,
         CustomPetMenu, TimeChanger, CustomTabList, TerminalSolver, ChamNametags,
         CustomSlotHighlight, InventoryDisplay, StopCloseMyChat, InventorySearchbar,
-        BlessingDisplay,
+        BlessingDisplay, ClientTimer,
 
         DungeonMap,
         DevOptions,

--- a/src/main/kotlin/noammaddons/features/impl/misc/ClientTimer.kt
+++ b/src/main/kotlin/noammaddons/features/impl/misc/ClientTimer.kt
@@ -1,0 +1,29 @@
+/**
+ * Noamm Addons - Timer Command
+ * This file has been automagically been JSdoc'ed by https://axle.coffee using OpenAI's GPT-4.1
+ * This file is part of the Noamm Addons project, which is licensed under the undefined license.
+ * This code may be subject to personal license(s) used by axle.coffee or other third parties, please contact a Contributor for more information.
+ *
+ */
+package noammaddons.features.impl.misc
+
+import noammaddons.features.Feature
+
+import noammaddons.ui.config.core.impl.DropdownSetting
+import noammaddons.ui.config.core.impl.TextInputSetting
+import noammaddons.ui.config.core.impl.ToggleSetting
+
+/**
+ * ClientTimer feature for scheduling actions like logout, quitting the game, or running a command.
+ *
+ * @property clientTimerMode Dropdown for selecting the timer mode ('logout', 'quit game', 'run command'). <- THIS IS A FUCKING INT FOR SOME REAOSN ITS LIKE ArRAY INT MAP WTFFF
+ * @property clientTimerCommand Text input for specifying the command to run in 'run command' mode.
+ * @property clientTimerCommandOnAllModes Toggle to run the command on all modes. boolean
+ */
+object ClientTimer: Feature("bdru me when i shizo and you shizo and you see this why are you still reading it GET OUT OF MY HEAD GET OUT OF M HEAD GET NJHOUT MF MY HEAD? NOW NOW NOW dev/ee3 lf invite can ee3 what is an ee3 he asks while i meow buti  meow wichi is a problem did i mention fuck axio axle was ratted by laskis in the big 20205 which is hobenstly quite sad now anyways i hope you;re doing very well sincei know i mam omeow meow meowm eowmekeopwm oewme") {
+    public val clientTimerMode by DropdownSetting("Mode", listOf("logout", "quit game", "run command"), 0)
+    public val clientTimerCommand by TextInputSetting("Command to run", "")
+    public val clientTimerCommandOnAllModes by ToggleSetting("Command on all modes", false)
+
+
+}


### PR DESCRIPTION
 Handles the /timer command for scheduling actions after a delay.
 
  Usage:
  /timer <time><unit>
  Examples: /timer 1d, /timer 2h, /timer 30m, /timer 45s, /timer 1hour
 
 Modes:
 - logout: Disconnects from the server and returns to the main menu.
 - quit game: Shuts down the Minecraft client.
 - run command: Executes a custom command after the timer.

 If called with no arguments and a timer is running, cancels the timer.
 
 
 